### PR TITLE
Change `трю` to the real maina word

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Моля](https://media.tenor.com/images/139208d8296e1e01a6e3fc41a14d624d/tenor.gif)
 
 ## Ключови думи
-* `True` => `трю`
+* `True` => `харабия`
 * `False` => `бомбок`
 * `and` => `и`
 * `or` => `или`

--- a/mynathon/mynathon.py
+++ b/mynathon/mynathon.py
@@ -16,7 +16,7 @@ class MynathonParser:
     """The class that is capable of converting mynathon to python."""
 
     KEYWORDS = {
-        "трю": "True",
+        "харабия": "True",
         "бомбок": "False",
         "и": "and",
         "или": "or",


### PR DESCRIPTION
Няма такава дума `трю`. Казва се `харабия`.